### PR TITLE
Add support for GPS via serial port

### DIFF
--- a/QtAgOpenGPS.pro
+++ b/QtAgOpenGPS.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui opengl quick quickwidgets network
+QT       += core gui opengl quick quickwidgets network serialport
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 lessThan(QT_MAJOR_VERSION, 5):error("requires Qt 5.9 or newer")

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Status of the Port
 As of March 14, 2020, the backend code is tracking the v4 branch of AOG,
 current to the March 10, 2020 commit.
 
-UI is still mostly non-present, and really only works with the built-in
-simulator, or a UDP data stream.  For testing purposes, a job and field
+UI is still mostly non-present, but works with the built-in simulator,
+UDP data stream, or a serial port. For testing purposes, a job and field
 is automatically started, and a demo AB line is defined at 5 degrees.
 
 Bugs

--- a/formgps.cpp
+++ b/formgps.cpp
@@ -18,8 +18,15 @@ FormGPS::FormGPS(QWidget *parent) :
     setupGui();
     AOGSettings s;
 
-    isUDPServerOn = s.value("port/udp_on", true).toBool();
+    /**************************
+     * SerialComm.Designer.cs *
+     **************************/
+    sp.setDataBits(QSerialPort::Data8);
+    sp.setParity(QSerialPort::NoParity);
+    sp.setStopBits(QSerialPort::OneStop);
 
+
+    isUDPServerOn = s.value("port/udp_on", true).toBool();
 
     /* test data to see if drawing routines are working. */
 

--- a/formgps.cpp
+++ b/formgps.cpp
@@ -108,6 +108,30 @@ FormGPS::FormGPS(QWidget *parent) :
 
     currentFieldDirectory = "TestField";
 
+    /*****************************
+     * FormGPS.cs:FormGPS_Load() *
+     *****************************/
+    //set baud and port from last time run
+    // TODO QAOG load setting
+    portNameGPS = s.value("port/portNameGPS", "ttyACM0").toString();
+    baudRateGPS = s.value("port/baudRateGPS", QSerialPort::Baud115200).toInt();
+
+    //try and open
+    SerialPortOpenGPS();
+
+    if (sp.isOpen())
+    {
+        // TODO QAOG simulatorOnToolStripMenuItem.Checked = false;
+        qmlItem(qml_root,"simSpeed")->setProperty("visible", false);
+        qmlItem(qml_root,"simStopButton")->setProperty("visible", false);
+        qmlItem(qml_root,"simSteer")->setProperty("visible", false);
+        qmlItem(qml_root,"simSteerCenter")->setProperty("visible", false);
+
+        // TODO QAOG Settings.Default.setMenu_isSimulatorOn = simulatorOnToolStripMenuItem.Checked;
+        // TODO QAOG Settings.Default.Save();
+    }
+
+
     if (isUDPServerOn) startUDPServer();
 
     //TODO: connect signals from various classes

--- a/formgps.h
+++ b/formgps.h
@@ -14,6 +14,7 @@
 #include <QOpenGLFramebufferObject>
 #include <QOpenGLBuffer>
 #include <QQuickView>
+#include <QSerialPort>
 
 #include "common.h"
 
@@ -527,6 +528,15 @@ public:
     /**************************
      * SerialComm.Designer.cs *
      **************************/
+private:
+    QString portNameGPS = "COM GPS";
+    int baudRateGPS = QSerialPort::Baud4800;
+
+    //serial port gps is connected to
+    QSerialPort sp;
+
+    void SerialLineReceived(QByteArray sentence);
+
 public:
 
     double actualSteerAngleDisp;
@@ -535,6 +545,8 @@ public:
     void sectionControlOutToPort();
     void sendOutUSBAutoSteerPort(uchar *data, int pgnSentenceLength);
 
+    void SerialPortOpenGPS();
+    void SerialPortCloseGPS();
 
     /***********************
      * FormGPS.Designer.cs *
@@ -627,6 +639,11 @@ public slots:
      * From Position.Designer.cs
      */
     void processSectionLookahead(); //called when section lookahead GL stuff is rendered
+
+    /**************************
+     * SerialComm.Designer.cs *
+     **************************/
+    void sp_DataReceived();
 
     /*
      * simulator

--- a/formgps_serial.cpp
+++ b/formgps_serial.cpp
@@ -1,4 +1,5 @@
 #include "formgps.h"
+#include "qmlutil.h"
 
 void FormGPS::autoSteerDataOutToPort()
 {
@@ -13,4 +14,102 @@ void FormGPS::sendSteerSettingsOutAutoSteerPort()
 void FormGPS::sectionControlOutToPort()
 {
 
+}
+
+//called by the GPS delegate every time a chunk is rec'd
+void FormGPS::SerialLineReceived(QByteArray sentence)
+{
+    //spit it out no matter what it says
+    pn.rawBuffer.append(sentence);
+    //recvSentenceSettings = sbNMEAFromGPS.ToString()
+}
+
+//serial port receive in its own thread
+void FormGPS::sp_DataReceived()
+{
+    if (sp.isOpen())
+    {
+        //give it a sec to spit it out
+        //System.Threading.Thread.Sleep(2000);
+
+        //read whatever is in port
+        QByteArray sentence = sp.readAll();
+        SerialLineReceived(sentence);
+    }
+}
+
+void FormGPS::SerialPortOpenGPS()
+{
+    //close it first
+    SerialPortCloseGPS();
+
+    if (sp.isOpen())
+    {
+        // TODO QAOG simulatorOnToolStripMenuItem.Checked = false;
+        qmlItem(qml_root,"simSpeed")->setProperty("visible", false);
+        qmlItem(qml_root,"simStopButton")->setProperty("visible", false);
+        qmlItem(qml_root,"simSteer")->setProperty("visible", false);
+        qmlItem(qml_root,"simSteerCenter")->setProperty("visible", false);
+
+        // TODO QAOG Settings.Default.setMenu_isSimulatorOn = simulatorOnToolStripMenuItem.Checked;
+        // TODO QAOG Settings.Default.Save();
+    }
+
+
+    if (!sp.isOpen())
+    {
+        sp.setPortName(portNameGPS);
+        sp.setBaudRate(baudRateGPS);
+        connect(&sp, SIGNAL(readyRead()), this, SLOT(sp_DataReceived()));
+        // TODO QAOG sp.WriteTimeout = 1000;
+    }
+
+    if (!sp.open(QIODevice::ReadOnly))
+    {
+        //MessageBox.Show(exc.Message + "\n\r" + "\n\r" + "Go to Settings -> COM Ports to Fix", "No Serial Port Active");
+        //WriteErrorLog("Open GPS Port " + e.ToString());
+
+        //update port status labels
+        //stripPortGPS.Text = " * * ";
+        //stripPortGPS.ForeColor = Color.Red;
+        //stripOnlineGPS.Value = 1;
+
+        //SettingsPageOpen(0);
+    }
+
+    if (sp.isOpen())
+    {
+        //btnOpenSerial.Enabled = false;
+
+        //discard any stuff in the buffers
+        sp.clear(QSerialPort::AllDirections);
+
+        //update port status label
+        //stripPortGPS.Text = portNameGPS + " " + baudRateGPS.ToString();
+        //stripPortGPS.ForeColor = Color.ForestGreen;
+
+        // TODO QAOG Properties.Settings.Default.setPort_portNameGPS = portNameGPS;
+        // TODO QAOG Properties.Settings.Default.setPort_baudRate = baudRateGPS;
+        // TODO QAOG Properties.Settings.Default.Save();
+    }
+}
+
+void FormGPS::SerialPortCloseGPS()
+{
+    //if (sp.IsOpen)
+    {
+        // TODO QAOG sp.DataReceived -= sp_DataReceived;
+        sp.close();
+        if (sp.error() != QSerialPort::NoError)
+        {
+            // TODO QAOG WriteErrorLog("Closing GPS Port" + e.ToString());
+            // TODO QAOG MessageBox.Show(e.Message, "Connection already terminated?");
+        }
+
+        //update port status labels
+        //stripPortGPS.Text = " * * " + baudRateGPS.ToString();
+        //stripPortGPS.ForeColor = Color.ForestGreen;
+        //stripOnlineGPS.Value = 1;
+        // TODO QAOG sp.Dispose();
+    }
 }

--- a/formgps_sim.cpp
+++ b/formgps_sim.cpp
@@ -15,14 +15,17 @@ void FormGPS::onSimTimerTimeout()
     qmlobject = qmlItem(qml_root, "simSteer");
     double steerAngle = (qmlobject->property("value").toReal() - 300) * 0.1;
 
-    //TODO: if not serial
-    if (isAutoSteerBtnOn && (vehicle.guidanceLineDistanceOff != 32000))
-        sim.DoSimTick(vehicle.guidanceLineSteerAngle * 0.01);
-    else if (recPath.isDrivingRecordedPath)
-        sim.DoSimTick(vehicle.guidanceLineSteerAngle * 0.01);
-    //else if (self.isSelfDriving) sim.DoSimTick(guidanceLineSteerAngle * 0.01);
-    else
-        //TODO: sim.DoSimTick(sim.steerAngleScrollBar);
-        sim.DoSimTick(steerAngle); //drive straight for now until UI
+    //if a GPS is connected disable sim
+    if (!sp.isOpen())
+    {
+        if (isAutoSteerBtnOn && (vehicle.guidanceLineDistanceOff != 32000))
+            sim.DoSimTick(vehicle.guidanceLineSteerAngle * 0.01);
+        else if (recPath.isDrivingRecordedPath)
+            sim.DoSimTick(vehicle.guidanceLineSteerAngle * 0.01);
+        //else if (self.isSelfDriving) sim.DoSimTick(guidanceLineSteerAngle * 0.01);
+        else
+            //TODO: sim.DoSimTick(sim.steerAngleScrollBar);
+            sim.DoSimTick(steerAngle); //drive straight for now until UI
+    }
 
 }


### PR DESCRIPTION
Hi,
this PR adds support for receiving NMEA data over serial port. The implementation follows original AgOpenGPS code as far as possible. Tested on AMD64 and Aarch64 (Rpi4). I kept original comments and marked unimplemented parts by _TODO QAOG_ (such a code depends on interface which is not available in QtAOG, yet).